### PR TITLE
hard-code web3 to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@orbs-network/orbs-ethereum-contracts-v2": "0.0.12",
     "jest": "^26.0.1",
-    "web3": "^1.2.6"
+    "web3": "1.2.6"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
contracts testkit requires 1.2.6 and working with 1.2.7 isn't smooth so best to rely on it directly